### PR TITLE
chore(docs): correct event-name to close overlay

### DIFF
--- a/docs/docs/systems/overlays/overview.md
+++ b/docs/docs/systems/overlays/overview.md
@@ -44,7 +44,7 @@ html`
     <div slot="content">
       This is an overlay
       <button
-        @click=${e => e.target.dispatchEvent(new Event('overlay-close', { bubbles: true }))}
+        @click=${e => e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }))}
       >x</button>
     <div>
     <button slot="invoker">


### PR DESCRIPTION
renames the event-name in a docs example from `overlay-close` to `close-overlay`